### PR TITLE
(fix) 旧Hubのリダイレクトがちゃんと効くようにした

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -150,6 +150,13 @@ export default defineNuxtConfig({
 	},
 	nitro: {
 		preset: 'vercel',
+		vercel: {
+			config: {
+				routes: [
+					...getOldHubRedirects(),
+				],
+			}
+		},
 		plugins: [
 			'@/server/plugins/appendComment.ts',
 			'@/server/plugins/i18nRedirector.ts',

--- a/scripts/get-old-hub-redirects.ts
+++ b/scripts/get-old-hub-redirects.ts
@@ -1,10 +1,30 @@
+import { writeFileSync } from 'fs';
 import { redirects } from './../assets/data/old-hub-redirects';
 import { localesConst } from './../assets/data/locales';
 import type { LocaleCodes } from './../assets/data/locales';
 import type { NuxtConfig } from 'nuxt/schema';
-import { joinURL } from 'ufo';
+import { joinURL, cleanDoubleSlashes } from 'ufo';
 
-export function getOldHubRedirects(): NuxtConfig['routeRules'] {
+type VercelRouteSource = {
+    src: string;
+    dest?: string;
+    headers?: Record<string, string>;
+    methods?: string[];
+    continue?: boolean;
+    caseSensitive?: boolean;
+    check?: boolean;
+    status?: number;
+    has?: Array<unknown>;
+    missing?: Array<unknown>;
+    locale?: {
+        redirect?: Record<string, string>;
+        cookie?: string;
+    };
+    middlewareRawSrc?: string[];
+    middlewarePath?: string;
+};
+
+export function getOldHubRedirects():VercelRouteSource[] {
 
     // 旧Hub時代の各言語のプレフィックス
     const hubLocales: Record<LocaleCodes, string> = {
@@ -19,25 +39,38 @@ export function getOldHubRedirects(): NuxtConfig['routeRules'] {
         tw: '/zh-TW',
     };
 
-    const out: NuxtConfig['routeRules'] = {};
+    const out:VercelRouteSource[] = [];
 
-    localesConst.forEach((locale) => {
-        redirects.forEach((route) => {
-            if (route[0].startsWith('/ns')) return;
+    redirects.forEach((route) => {
+        if (route[0].startsWith('/ns')) return;
 
-            let destination = route[1];
+        let destination = route[1];
 
-            if (route[0].endsWith('.html') && !new RegExp(`^/(${localesConst.map((e) => e.code).join('|')})/`, 'g').test(destination)) {
-                destination = joinURL(`/${locale.code}`, destination);
-            }
+        if (!new RegExp(`^/(${localesConst.map((e) => e.code).join('|')})/`, 'g').test(destination)) {
+            destination = joinURL(`$1/`, destination);
+        }
 
-            out[joinURL(hubLocales[locale.code], route[0])] = {
-                redirect: {
-                    to: destination,
-                    statusCode: 301,
-                },
-            };
+        out.push({
+            src: joinURL(`(${Object.values(hubLocales).map((v) => v === '/' ? '' : v).join('|')})/`, route[0]).replace(/(?<!\\)\./g, '\\.'),
+            headers: {
+                'Location': destination,
+            },
+            status: 308,
         });
+    });
+
+    out.push({
+        src: '/zh-CN/(.*)',
+        headers: {
+            'Location': '/cn/$1',
+        },
+        status: 307,
+    }, {
+        src: '/zh-TW/(.*)',
+        headers: {
+            'Location': '/tw/$1',
+        },
+        status: 307,
     });
 
     return out;


### PR DESCRIPTION
Vercelに正規表現を直接ぶち込んでリダイレクトの個数制限を回避

Fix #53