### PR TITLE
docs: docker-compose.yml.exampleのファイル名修正

### DIFF
--- a/content/ja/docs/3.for-admin/install/guides/docker.md
+++ b/content/ja/docs/3.for-admin/install/guides/docker.md
@@ -30,7 +30,7 @@ git checkout master
 ```sh
 cp .config/docker_example.yml .config/default.yml
 cp .config/docker_example.env .config/docker.env
-cp ./docker-compose.yml.example ./docker-compose.yml
+cp ./docker-compose_example.yml ./docker-compose.yml
 ```
 
 `default.yml`と`docker.env`をファイル内の説明に従って編集してください。  


### PR DESCRIPTION
https://github.com/misskey-dev/misskey/pull/12530 により、 `docker-compose.yml.example` が `docker-compose_example.yml` にリネームされているので、ドキュメントをそれに追従させます。