### PR TITLE
Nginx 1.25.1以降に表示されるhttp2の警告を修正

### DIFF
--- a/content/ja/docs/3.for-admin/install/resources/nginx.md
+++ b/content/ja/docs/3.for-admin/install/resources/nginx.md
@@ -50,8 +50,9 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
     server_name example.tld;
 
     ssl_session_timeout 1d;


### PR DESCRIPTION
listen … http2ディレクティブはNGINX 1.25.1で非推奨となりました。
ソース：https://www.f5.com/ja_jp/company/blog/nginx/nginx-plus-r30-released