### PR TITLE
docs: サーバーホストをexample TLDに置き換え

### DIFF
--- a/content/ja/docs/4.for-developers/api/token/50.app.md
+++ b/content/ja/docs/4.for-developers/api/token/50.app.md
@@ -59,7 +59,7 @@ console.log(i)
 
 ## 5. 実際にテストする
 ```javascript
-fetch("https://misskey.io/api/notes/create", {
+fetch("https://misskey.example/api/notes/create", {
     method: 'POST',
     body: JSON.stringify({
         i: "/* ここにiを入力 */",


### PR DESCRIPTION
misskey.ioのみではないため