### PR TITLE
docs: fix typo CloudFlare to Cloudflare

### DIFF
--- a/content/cn/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/cn/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 - ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 - メモリは4GB程度あると良い。
   - （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-- 独自のドメインを購入し、CloudFlareを使用する。
+- 独自のドメインを購入し、Cloudflareを使用する。
 - ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 - ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2. Global API KeyのViewを選択
 3. パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/en/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/en/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 - ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 - メモリは4GB程度あると良い。
   - （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-- 独自のドメインを購入し、CloudFlareを使用する。
+- 独自のドメインを購入し、Cloudflareを使用する。
 - ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 - ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2. Global API KeyのViewを選択
 3. パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/fr/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/fr/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 - ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 - メモリは4GB程度あると良い。
   - （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-- 独自のドメインを購入し、CloudFlareを使用する。
+- 独自のドメインを購入し、Cloudflareを使用する。
 - ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 - ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2. Global API KeyのViewを選択
 3. パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/id/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/id/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 - ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 - メモリは4GB程度あると良い。
   - （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-- 独自のドメインを購入し、CloudFlareを使用する。
+- 独自のドメインを購入し、Cloudflareを使用する。
 - ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 - ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2. Global API KeyのViewを選択
 3. パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/it/.docs-legacy/install/ubuntu-manual.md
+++ b/content/it/.docs-legacy/install/ubuntu-manual.md
@@ -223,11 +223,11 @@ Attiva la partenza automatica al riavvio: `sudo systemctl enable ufw`
 ufw semplifica l'uso di Netfilter (IPTABLES)
 :::
 
-### CloudFlare
+### Cloudflare
 
 Si tratta di un servizio utile per gestire DNS, Reverse Proxy e CDN sul tuo dominio. Si può anche evitare ma è consigliato, oltre che comodo. [Configurazione CDN](../admin/cdn)
 
-[Iscrizione a CloudFlare](https://dash.cloudflare.com/sign-up) segui le indicazioni per configurare il dominio prescelto.
+[Iscrizione a Cloudflare](https://dash.cloudflare.com/sign-up) segui le indicazioni per configurare il dominio prescelto.
 
 Digita l'indirizzo IP del server nella schermata DNS. A seconda del servizio, potrebbero essere necessarie fino a 48 ore prima della ricezione delle configurazioni.
 
@@ -390,7 +390,7 @@ Dovresti vedere la pagina iniziale di Misskey. Inizia a verificare se funziona.
 
 ### Se non riesci ad accedere
 
-#### Controlla il DNS di CloudFlare
+#### Controlla il DNS di Cloudflare
 
 Visita il sito Cloudflare e verifica che la configurazione DNS punti verso l'indirizzo IP che hai indicato.
 

--- a/content/it/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/it/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 - ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 - メモリは4GB程度あると良い。
   - （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-- 独自のドメインを購入し、CloudFlareを使用する。
+- 独自のドメインを購入し、Cloudflareを使用する。
 - ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 - ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2. Global API KeyのViewを選択
 3. パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/ja/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/ja/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 *   ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 *   メモリは4GB程度あると良い。
     *   （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-*   独自のドメインを購入し、CloudFlareを使用する。
+*   独自のドメインを購入し、Cloudflareを使用する。
 *   ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 *   ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2.  Global API KeyのViewを選択
 3.  パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/ko/.docs-legacy/install/ubuntu-manual.md
+++ b/content/ko/.docs-legacy/install/ubuntu-manual.md
@@ -50,7 +50,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 *   OSは**Ubuntu 22.04.1 LTS**を利用する。
 *   ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 *   メモリは1.5GB程度あればよい。（Viteの導入等により、1.5GB程度でもビルド可能になった）
-*   独自のドメインを購入し、CloudFlareを使用する。
+*   独自のドメインを購入し、Cloudflareを使用する。
 *   ドメインは[Google Domains](https://domains.google/intl/ja_jp/)などで予め用意しておくこと。
 *   ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -241,7 +241,7 @@ sudo apt install -y git build-essential
 サーバーをインターネットに公開する準備をする。
 
 :::tip
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 :::
 
 ### ファイヤーウォール
@@ -278,13 +278,13 @@ sudo systemctl enable ufw
 ufwは、netfilter(iptables)を人間が操作しやすいようにするアプリだ。インストールスクリプトは、OCI環境ではnetfilterを直接操作する。
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](/docs/admin/cdn.html)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -292,9 +292,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -306,14 +306,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2.  Global API KeyのViewを選択
 3.  パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -505,9 +505,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/ko/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/ko/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OS의 차이, Misskey 본체나 의존하는 소프트웨어의 버전업으로 
 - 하드웨어 요구 사항으로 CPU는 최신 제품이라면 최소사양으로도 작동합니다.아키텍처는 amd64 및 arm64를 가정합니다.
 - 램은 4GB 정도 있으면 충분합니다.
   - (기존에 Vite의 도입으로 1.5GB만 있어도 빌드가 가능하다고 설명했지만, 최근 들어 프론트엔드 빌드 문제로 필요한 용량이 늘어났습니다.）
-- 자체 도메인을 구입하고 CloudFlare를 사용하세요.
+- 자체 도메인을 구입하고 Cloudflare를 사용하세요.
 - 도메인은 [Google Domains](https://domains.google/intl/ja_jp/) 등에서 미리 준비해야 합니다.
 - 여기서는 도메인을 example.tld로 설명할 것이므로, 자신이 구입한 도메인으로 적절히 대체하여 읽도록 합니다.개발 환경의 경우 localhost로 대체합니다(설정 파일 항목에서 별도 설명).
 
@@ -246,13 +246,13 @@ sudo apt install -y git build-essential
 
 :::tip
 
-개발 환경의 경우 방화벽, CloudFlare, Certbot 설정이 필요하지 않습니다.
+개발 환경의 경우 방화벽, Cloudflare, Certbot 설정이 필요하지 않습니다.
 
 :::
 
 ### 방화벽
 
-HTTPS･WSS 통신에 사용할 인증서를 CloudFlare를 사용하는 방식으로 Let's Encrypt에서 발급받습니다.
+HTTPS･WSS 통신에 사용할 인증서를 Cloudflare를 사용하는 방식으로 Let's Encrypt에서 발급받습니다.
 
 다음은 접속 허용을 화이트리스트 형식으로 하여 22번 SSH 포트를 접속 횟수 제한을 두어 개방하고, 80번 HTTP 포트와 443번 HTTPS 포트를 개방하는 예입니다.
 
@@ -286,13 +286,13 @@ ufw는 넷필터(iptables)를 사람이 쉽게 조작할 수 있도록 하는 �
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlare는 자신의 도메인에 대해 DNS 서버, 리버스 프록시, CDN을 한 번에 제공해 주는 매우 편리한 서비스입니다.\
-CloudFlare를 경유하지 않고 서버를 공개하는 것도 가능하지만, 매우 편리하기 때문에 도입하는 것이 좋습니다.
+Cloudflare는 자신의 도메인에 대해 DNS 서버, 리버스 프록시, CDN을 한 번에 제공해 주는 매우 편리한 서비스입니다.\
+Cloudflare를 경유하지 않고 서버를 공개하는 것도 가능하지만, 매우 편리하기 때문에 도입하는 것이 좋습니다.
 [**→ CDN 설정**](../resources/cdn/)
 
-[CloudFlare에 가입(https://dash.cloudflare.com/sign-up)하고, 구매한 도메인을 안내에 따라 등록합니다.
+[Cloudflare에 가입(https://dash.cloudflare.com/sign-up)하고, 구매한 도메인을 안내에 따라 등록합니다.
 
 DNS 등록 화면에서 서버의 IP 주소를 입력하면 됩니다.
 
@@ -300,9 +300,9 @@ DNS 등록 화면에서 서버의 IP 주소를 입력하면 됩니다.
 
 ### Certbot (Let's Encrypt) 설정
 
-HTTPS･WSS 통신에 사용할 인증서를 CloudFlare를 사용하는 방식으로 Let's Encrypt에서 발급받습니다.
+HTTPS･WSS 통신에 사용할 인증서를 Cloudflare를 사용하는 방식으로 Let's Encrypt에서 발급받습니다.
 
-certbot과 CloudFlare 플러그인 설치하기
+certbot과 Cloudflare 플러그인 설치하기
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ Cloudflare의 API 키를 얻습니다.아래 절차에 따라 취득합니다.
 2. Global API Key의 View 선택
 3. 비밀번호 입력 및 hCaptcha 해제, View 선택
 
-CloudFlare의 정보를 담은 설정 파일 /etc/cloudflare/cloudflare.ini를 생성합니다.
+Cloudflare의 정보를 담은 설정 파일 /etc/cloudflare/cloudflare.ini를 생성합니다.
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email(아래 예에서는 bar\@fuga.foo)에는 CloudFlare에 등록한 이메일 주소를 설정합니다.
+dns_cloudflare_email(아래 예에서는 bar\@fuga.foo)에는 Cloudflare에 등록한 이메일 주소를 설정합니다.
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskey의 웰컴 페이지가 표시되어야 합니다.
 
 ### 액세스 할 수 없는 경우
 
-#### CloudFlare의 DNS 확인하기
+#### Cloudflare의 DNS 확인하기
 
-CloudFlare의 DNS 설정이 올바른 IP 주소로 설정되어 있는지 다시 한 번 확인해봅니다.
+Cloudflare의 DNS 설정이 올바른 IP 주소로 설정되어 있는지 다시 한 번 확인해봅니다.
 
 #### 라우터 설정 확인하기
 

--- a/content/pl/.docs-legacy/admin/nginx.md
+++ b/content/pl/.docs-legacy/admin/nginx.md
@@ -5,7 +5,7 @@
 2. Zmień go w taki sposób:
    1. Zamień example.tld z domeną którą przygotowałeś.\
      `ssl_certificate` i `ssl_certificate_key` powinny być lokalizacjami certyfikatu od Let's Encrypt.
-   2. Jeżeli używasz CDNa jak na przykład CloudFlare, usuń 4 linijki  "If it's behind another reverse proxy or CDN, remove the following."
+   2. Jeżeli używasz CDNa jak na przykład Cloudflare, usuń 4 linijki  "If it's behind another reverse proxy or CDN, remove the following."
 3. Jeżeli stworzysz `/etc/nginx/sites-available/misskey.conf`, stwórz symlink jako `/etc/nginx/sites-enabled/misskey.conf`.\
    `sudo ln -s /etc/nginx/sites-available/misskey.conf /etc/nginx/sites-enabled/misskey.conf`
 4. Wykonaj `sudo nginx -t` aby zweryfikować działanie konfiguracji.

--- a/content/pl/.docs-legacy/install/bash.md
+++ b/content/pl/.docs-legacy/install/bash.md
@@ -14,13 +14,13 @@ Poza jest też skrypt do aktualizacji Misskey.
 ## Składniki
 1. Domena
 2. Serwer (najlepiej się sprawdzi Ubuntu)
-3. Konto CloudFlare (zalecane)
+3. Konto Cloudflare (zalecane)
 
 :::danger
 Nigdy nie zmieniaj nazwy domeny (hostname) instancji kiedy zaczniesz z niej korzystać!!
 :::
 
-## Skonfiguruj CloudFlare
+## Skonfiguruj Cloudflare
 Jeśli korzystasz z nginx i Cloudflare, musisz skonfigurować Cloudflare:
 
 - Ustaw DNS.

--- a/content/pl/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/pl/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 - ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 - メモリは4GB程度あると良い。
   - （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-- 独自のドメインを購入し、CloudFlareを使用する。
+- 独自のドメインを購入し、Cloudflareを使用する。
 - ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 - ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2. Global API KeyのViewを選択
 3. パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/th/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/th/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 - ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 - メモリは4GB程度あると良い。
   - （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-- 独自のドメインを購入し、CloudFlareを使用する。
+- 独自のドメインを購入し、Cloudflareを使用する。
 - ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 - ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2. Global API KeyのViewを選択
 3. パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 

--- a/content/tw/docs/3.for-admin/install/guides/ubuntu-manual.md
+++ b/content/tw/docs/3.for-admin/install/guides/ubuntu-manual.md
@@ -54,7 +54,7 @@ OSの違い、Misskey本体や依存するソフトウェアのバージョン�
 - ハードウェア要件としては、CPUは最近のものなら最小限で動く。アーキテクチャはamd64及びarm64を想定している。
 - メモリは4GB程度あると良い。
   - （従来Viteの導入により1.5GB程度でもビルド可能と説明していたが、最近またフロントエンドのビルドで要件が厳しくなってきた。）
-- 独自のドメインを購入し、CloudFlareを使用する。
+- 独自のドメインを購入し、Cloudflareを使用する。
 - ドメインは[Cloudflare Registrar](https://www.cloudflare.com/ja-jp/products/registrar/)などで予め用意しておくこと。
 - ここではドメインをexample.tldとして解説を進めるので、自分が買ったドメインに適宜置き換えて読むこと。開発環境の場合はlocalhostと読み替えます（設定ファイルの項で別途説明）
 
@@ -246,7 +246,7 @@ sudo apt install -y git build-essential
 
 :::tip
 
-開発環境の場合はファイヤーウォールやCloudFlare、Certbotの設定は不要です
+開発環境の場合はファイヤーウォールやCloudflare、Certbotの設定は不要です
 
 :::
 
@@ -286,13 +286,13 @@ ufwは、netfilter(iptables)を人間が操作しやすいようにするアプ�
 
 :::
 
-### CloudFlare
+### Cloudflare
 
-CloudFlareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
-CloudFlareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
+Cloudflareは、自分のドメインに対してDNSサーバー・リバースプロキシ・CDNをいっぺんに提供してくれるたいへん便利なサービスである。\
+Cloudflareを経由せずにサーバーを公開することも可能だが、たいへん便利なので導入することをお勧めする。
 [**→ CDNの設定**](../resources/cdn/)
 
-[CloudFlareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
+[Cloudflareにサインアップ](https://dash.cloudflare.com/sign-up) し、購入したドメインを案内に従って登録する。
 
 DNSの登録画面でサーバーのIPアドレスを入力しておくとよい。
 
@@ -300,9 +300,9 @@ DNSの登録画面でサーバーのIPアドレスを入力しておくとよい
 
 ### Certbot (Let’s Encrypt) の設定
 
-HTTPS･WSS通信に使用する証明書をCloudFlareを使う方式でLet’s Encryptから取得する。
+HTTPS･WSS通信に使用する証明書をCloudflareを使う方式でLet’s Encryptから取得する。
 
-certbotとCloudFlareプラグインをインストール
+certbotとCloudflareプラグインをインストール
 
 ```sh
 sudo apt install -y certbot python3-certbot-dns-cloudflare
@@ -314,14 +314,14 @@ CloudflareのAPIキーを取得する。以下の手順で取得されたい。
 2. Global API KeyのViewを選択
 3. パスワードを入力しhCaptchaを解除、Viewを選択
 
-CloudFlareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
+Cloudflareの情報を記載した設定ファイル/etc/cloudflare/cloudflare.iniを作成する。
 
 ```sh
 mkdir /etc/cloudflare
 nano /etc/cloudflare/cloudflare.ini
 ```
 
-dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudFlareで登録しているメールアドレスを設定する。
+dns_cloudflare_email（下の例ではbar\@fuga.foo）にはCloudflareで登録しているメールアドレスを設定する。
 
 ```sh
 dns_cloudflare_email = bar@fuga.foo
@@ -517,9 +517,9 @@ Misskeyのウェルカムページが表示されるはずだ。
 
 ### アクセスできない場合
 
-#### CloudFlareのDNSを確認する
+#### CloudflareのDNSを確認する
 
-CloudFlareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
+CloudflareのDNS設定が正しいIPアドレスになっているかもう一度確認しよう。
 
 #### ルーターの設定を確認する
 


### PR DESCRIPTION
Cloudflareの正式表記はfが小文字と思われます。

https://www.cloudflare.com/ja-jp/press-kit/
