### PR TITLE
Fix register_page_view_interruptor code

### DIFF
--- a/content/ja/docs/4.for-developers/plugin/plugin-api-reference.md
+++ b/content/ja/docs/4.for-developers/plugin/plugin-api-reference.md
@@ -199,7 +199,7 @@ Page閲覧時にPage情報を書き換えます。\
 コールバック関数の返り値でPageが書き換えられます。
 
 ```AiScript
-Plugin:register_note_post_interruptor(@(page) {
+Plugin:register_page_view_interruptor(@(page) {
   
   // ページの中身を書き換える（省略）
 


### PR DESCRIPTION
The code snippet for `register_page_view_interruptor` says `register_note_post_interruptor` instead. This PR fixes that issue.