### PR TITLE
docs: kubernetes ページの TIP ラベル修正

### DIFF
--- a/content/ja/docs/3.for-admin/install/guides/kubernetes.md
+++ b/content/ja/docs/3.for-admin/install/guides/kubernetes.md
@@ -17,7 +17,7 @@ MisskeyのHelmChartsはTrueNAS Scaleで使用するためのTrueChartsで公開�
 現在、Misskeyは*incubator* trainで進行中です。
 
 
-:::前提条件
+:::tip{label='前提条件'}
 
 - TrueNAS Scale
 または


### PR DESCRIPTION
tip{label=''} が指定されていなかったので追加