### PR TITLE
docs(theme): fix base theme links

### DIFF
--- a/content/ja/docs/2.for-users/3.features/theme.md
+++ b/content/ja/docs/2.for-users/3.features/theme.md
@@ -51,8 +51,8 @@
 ベーステーマは、このテーマの`base`が`light`なら[_light.json5]で、`dark`なら[_dark.json5]です。
 つまり、このテーマ内の`props`に`panel`というキーが無くても、そこにはベーステーマの`panel`があると見なされます。
 
-- [_light.json5]: https://github.com/misskey-dev/misskey/blob/develop/packages/frontend/src/themes/_light.json5
-- [_dark.json5]:  https://github.com/misskey-dev/misskey/blob/develop/packages/frontend/src/themes/_dark.json5
+[_light.json5]: https://github.com/misskey-dev/misskey/blob/develop/packages/frontend-shared/themes/_light.json5
+[_dark.json5]:  https://github.com/misskey-dev/misskey/blob/develop/packages/frontend-shared/themes/_dark.json5
 
 #### バリューで使える構文
 * 16進数で表された色


### PR DESCRIPTION
Update links to correct locations and remove invalid list markers so links are clickable in rendered docs.