### PR TITLE
docs(theme): update links to inline format for clickable URLs

### DIFF
--- a/content/ja/docs/2.for-users/3.features/theme.md
+++ b/content/ja/docs/2.for-users/3.features/theme.md
@@ -48,11 +48,8 @@
 `props`下にはテーマのスタイルを定義します。
 キーがCSSの変数名になり、バリューで中身を指定します。
 なお、この`props`オブジェクトはベーステーマから継承されます。
-ベーステーマは、このテーマの`base`が`light`なら[_light.json5]で、`dark`なら[_dark.json5]です。
+ベーステーマは、このテーマの`base`が`light`なら[_light.json5](https://github.com/misskey-dev/misskey/blob/develop/packages/frontend-shared/themes/_light.json5)で、`dark`なら[_dark.json5](https://github.com/misskey-dev/misskey/blob/develop/packages/frontend-shared/themes/_dark.json5)です。
 つまり、このテーマ内の`props`に`panel`というキーが無くても、そこにはベーステーマの`panel`があると見なされます。
-
-[_light.json5]: https://github.com/misskey-dev/misskey/blob/develop/packages/frontend-shared/themes/_light.json5
-[_dark.json5]:  https://github.com/misskey-dev/misskey/blob/develop/packages/frontend-shared/themes/_dark.json5
 
 #### バリューで使える構文
 * 16進数で表された色


### PR DESCRIPTION
After reviewing the updated official documentation from PR #373 , I noticed that the links for _light.json5 and _dark.json5 were still not clickable. I’ve now updated the links to inline format to ensure they are clickable in the rendered docs.