### PR TITLE
docs(theme): fix reference-style links for base themes

### DIFF
--- a/content/ja/docs/2.for-users/3.features/theme.md
+++ b/content/ja/docs/2.for-users/3.features/theme.md
@@ -48,7 +48,7 @@
 `props`下にはテーマのスタイルを定義します。
 キーがCSSの変数名になり、バリューで中身を指定します。
 なお、この`props`オブジェクトはベーステーマから継承されます。
-ベーステーマは、このテーマの`base`が`light`なら[_light.json5]で、`dark`なら[_dark.json5]です。
+ベーステーマは、このテーマの`base`が`light`なら[_light.json5][_light.json5]で、`dark`なら[_dark.json5][_dark.json5]です。
 つまり、このテーマ内の`props`に`panel`というキーが無くても、そこにはベーステーマの`panel`があると見なされます。
 
 [_light.json5]: https://github.com/misskey-dev/misskey/blob/develop/packages/frontend-shared/themes/_light.json5


### PR DESCRIPTION
Fix incomplete reference-style links so that _light.json5 and _dark.json5 are rendered as clickable links in the Japanese documentation.