### PR TITLE
add: rescript-misskey-api to libraries.md

### DIFF
--- a/content/ja/docs/4.for-developers/api/libraries.md
+++ b/content/ja/docs/4.for-developers/api/libraries.md
@@ -37,3 +37,7 @@ description: 'Misskey APIに関連するライブラリの一覧'
 ## Rust
 
 - [misskey-rs](https://github.com/coord-e/misskey-rs)
+
+## ReScript
+
+- [rescript-misskey-api](https://github.com/f3liz-dev/rescript-misskey-api)


### PR DESCRIPTION
「ライブラリの一覧」へのPRです。
ReScript (AltJS, https://rescript-lang.org )用のMisskey APIライブラリです。
十分動くレベルになったので、送ってみます。