### PR TITLE
enhance: add i18n for Search MFM

### DIFF
--- a/components/mk/Google.vue
+++ b/components/mk/Google.vue
@@ -1,7 +1,7 @@
 <template>
     <div :class="$style.root">
         <input v-model="query" :class="$style.input" type="search" :placeholder="q">
-        <button :class="$style.button" @click="search"><SearchIco /> 検索</button>
+        <button :class="$style.button" @click="search"><SearchIco /> {{ $t('_mk.searchByGoogle') }}</button>
     </div>
 </template>
 

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -348,6 +348,9 @@ _content:
   danger: "警告"
   preview: "プレビュー"
 
+_mk:
+  searchByGoogle: "検索"
+
 _other:
   title: "もっと！"
   description: "Misskeyをもっと楽しめるその他のリソースをご紹介しています。"


### PR DESCRIPTION
MFMの検索ボタンの文字列に `$t('_mk.searchByGoogle')` を使うようにしました。

Fix #392 