### PR TITLE
docs: add document for unixtime

### DIFF
--- a/content/ja/docs/2.for-users/3.features/mfm.md
+++ b/content/ja/docs/2.for-users/3.features/mfm.md
@@ -135,6 +135,15 @@ $[ruby Misskey ミスキー]
 
 <MfmPreview text="$[ruby Misskey ミスキー]"></MfmPreview>
 
+### 日時
+UNIX時間を指定して日時を表示できます。
+
+```
+$[unixtime 1701356400]
+```
+
+<MfmPreview text="$[unixtime 1701356400]"></MfmPreview>
+
 ### コード(インライン)
 プログラムなどのコードをインラインでシンタックスハイライトします。
 ```


### PR DESCRIPTION
mfm.mdに `$[unixtime` の説明を追加しました

文章と例は[リリースノート](https://misskey-hub.net/ja/docs/releases/#_2023111)から取りました
面白い日付があれば変えてもいいと思います

Fix #345 