### PR TITLE
Update rescript-misskey-api link in libraries.md

### DIFF
--- a/content/ja/docs/4.for-developers/api/libraries.md
+++ b/content/ja/docs/4.for-developers/api/libraries.md
@@ -7,6 +7,7 @@ description: 'Misskey APIに関連するライブラリの一覧'
 ## JavaScript
 
 - [misskey.js](https://github.com/misskey-dev/misskey/tree/develop/packages/misskey-js)
+- [rescript-misskey-api](https://github.com/f3liz-casa/rescript-misskey-api)
 
 ## Java
 
@@ -40,4 +41,4 @@ description: 'Misskey APIに関連するライブラリの一覧'
 
 ## ReScript
 
-- [rescript-misskey-api](https://github.com/f3liz-dev/rescript-misskey-api)
+- [rescript-misskey-api](https://github.com/f3liz-casa/rescript-misskey-api)


### PR DESCRIPTION
f3liz-dev -> f3liz-casa へGitHubでのorgs名をリネームしました。
また、rescript-misskey-apiはTSをサポートしましたので、 `# JavaScript`へ追加をリクエストします。