### PR TITLE
chore: pnpm v10 の仕様に合わせて設定ファイルを移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,16 +49,5 @@
     "nanoid": "^5.1.6",
     "swiper": "^12.0.3",
     "tinycolor2": "^1.6.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@aiscript-dev/aiscript-languageserver": "-"
-    },
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "better-sqlite3",
-      "esbuild",
-      "vue-demi"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+overrides:
+  "@aiscript-dev/aiscript-languageserver": "-"
+
+allowBuilds:
+  "@parcel/watcher": true
+  "better-sqlite3": true
+  "esbuild": true
+  "vue-demi": true


### PR DESCRIPTION
## 概要
現在のプロジェクトで `pnpm install` を実行すると、`pnpm@10` の仕様変更により以下の警告（Warning）が発生していました。

> [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides", "pnpm.onlyBuiltDependencies". See https://pnpm.io/settings for the new home of each setting.

## 変更内容
この警告を解消し、将来的な pnpm のバージョンアップにも対応できるよう、設定を現代の標準仕様に移行しました。
- `package.json` 内にあった非推奨の `"pnpm"` フィールドを削除しました。
- `overrides` と `onlyBuiltDependencies` (現 `allowBuilds`) の設定を、新しく作成した `pnpm-workspace.yaml` に移動させました。

## 確認事項
- [x] ローカル環境で警告が出なくなったことを確認しました。
- [x] パッケージのインストールとビルドが正常に完了することを確認しました。

よろしくお願いいたします。