### PR TITLE
perf: プリレンダリング中の Content API をキャッシュすることで SSG を約30%高速化

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,6 +29,7 @@ function getRouteRules(): NuxtConfig['routeRules'] | undefined {
 
 	// 言語ごとに割り当てる必要のないRouteRules
 	const staticRules: NuxtConfig['routeRules'] = {
+		// SSG のビルド中のみ有効になることを意図したキャッシュ
 		'/api/_content/**': { cache: { maxAge: 60 * 60 } },
 		'/ja/blog/**': { isr: true },
 		'/ns/': { prerender: true },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,6 +29,7 @@ function getRouteRules(): NuxtConfig['routeRules'] | undefined {
 
 	// 言語ごとに割り当てる必要のないRouteRules
 	const staticRules: NuxtConfig['routeRules'] = {
+		'/api/_content/**': { cache: { maxAge: 60 * 60 } },
 		'/ja/blog/**': { isr: true },
 		'/ns/': { prerender: true },
 	};


### PR DESCRIPTION
## 概要

プリレンダリング中に繰り返し実行される Nuxt Content v2 の Content API を Nitro の route cache で再利用します。

Nuxt Content のクエリ URL にはビルド固有の integrity が含まれるため、別ビルドのレスポンスが再利用されることはありません。また、現在の GitHub Pages 構成ではデプロイ後に Nitro は動作せず、このキャッシュは実質的に SSG 中だけ有効です。

## 計測結果

同一環境で `pnpm generate:nuxt` を各構成1回ずつ実行しました。

| 構成 | Prerender | 全体 |
| --- | ---: | ---: |
| 変更なし | 266.55秒 | 288.61秒 |
| Content API キャッシュあり | 179.29秒 | 200.85秒 |

全体で87.76秒、約30.4%短縮しました。

## 確認

- `pnpm generate:nuxt` が成功すること
- 6,302 routes がプリレンダリングされること
- `git diff --check` が成功すること
